### PR TITLE
chore: update NPM contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,26 @@
 version: 2.1
+
 orbs:
-  node: circleci/node@1.1.4
+  node: circleci/node@5.0.0
+
 workflows:
   version: 2
   workflow:
     jobs:
       - build:
           context:
-            - npm
+            - npm-readonly
+      - publish:
+          context:
+            - npm-publish
             - github
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - main
+
 jobs:
   build:
     docker:
@@ -16,16 +28,17 @@ jobs:
     working_directory: ~/project
     steps:
       - checkout
-      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-      - node/with-cache:
-          steps:
-            - run: npm install
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+      - node/install-packages
       - run: npm run build
       - run: npm test
-      - when:
-          condition:
-            equal:
-              - main
-              - <<pipeline.git.branch>>
-          steps:
-            - run: npm run semantic-release
+
+  publish:
+    docker:
+      - image: circleci/node:erbium
+    working_directory: ~/project
+    steps:
+      - checkout
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+      - node/install-packages
+      - run: npm run semantic-release

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "grid-table",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
         "@homebound/tsconfig": "^1.0.2",
+        "@semantic-release/exec": "^5.0.0",
         "@types/jest": "^26.0.23",
         "conventional-changelog-conventionalcommits": "^4.5.0",
         "jest": "^26.6.3",
@@ -998,6 +1000,26 @@
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
       "dev": true
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-5.0.0.tgz",
+      "integrity": "sha512-t7LWXIvDJQbuGCy2WmMG51WyaGSLTvZBv9INvcI4S0kn+QjnnVVUMhcioIqhb0r3yqqarMzHVcABFug0q0OXjw==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/error": "^2.1.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=16.0.0 <18.0.0"
+      }
     },
     "node_modules/@semantic-release/github": {
       "version": "7.2.1",
@@ -8066,6 +8088,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12330,6 +12357,20 @@
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
       "dev": true
+    },
+    "@semantic-release/exec": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-5.0.0.tgz",
+      "integrity": "sha512-t7LWXIvDJQbuGCy2WmMG51WyaGSLTvZBv9INvcI4S0kn+QjnnVVUMhcioIqhb0r3yqqarMzHVcABFug0q0OXjw==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^2.1.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      }
     },
     "@semantic-release/github": {
       "version": "7.2.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@homebound/tsconfig": "^1.0.2",
+    "@semantic-release/exec": "^5.0.0",
     "@types/jest": "^26.0.23",
     "conventional-changelog-conventionalcommits": "^4.5.0",
     "jest": "^26.6.3",
@@ -46,6 +47,12 @@
         "@semantic-release/release-notes-generator",
         {
           "preset": "conventionalcommits"
+        }
+      ],
+      [
+        "@semantic-release/exec",
+        {
+          "prepareCmd": "npm run build"
         }
       ],
       "@semantic-release/npm",


### PR DESCRIPTION
https://app.shortcut.com/homebound-team/story/13496/regenerate-ci-npm-tokens

Our previous NPM token was quite old (2 years) and likely widely exposed before https://github.com/homebound-team/graphql-service/pull/2101 was merged.

This PR updates the CircleCI config to use two distinct `npm` contexts (read-only and publish). This reduces the risk of accidentally publishing in a step that should not. Additionally, it uses a new automation-type token that allows us to enable 2-Factor Auth for login but not for the publishing token.

Once I transition our projects, I will delete the old `npm` context.